### PR TITLE
Updates for latest dashboard and recording rule linting

### DIFF
--- a/.lint
+++ b/.lint
@@ -1,4 +1,7 @@
-exclusions:
+exclusions:    
+  panel-job-instance-rule:
+    reason: Poorly deprecated rule name for job, see target-job-rule and target-instance-rule below.
+    
   template-job-rule:
     reason: Job is hardcoded in the mixin config.    
   template-instance-rule:

--- a/tests.yaml
+++ b/tests.yaml
@@ -1087,8 +1087,8 @@ tests:
     - exp_labels:
         severity: warning
       exp_annotations:
-        summary: "The kubernetes apiserver has terminated 33.33% of its incoming requests."
-        description: "The kubernetes apiserver has terminated 33.33% of its incoming requests."
+        summary: "The kubernetes apiserver has terminated more than 20% of its incoming requests."
+        description: "The kubernetes apiserver in Cluster , has terminated 33.33% of its incoming requests."
         runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapiterminatedrequests"
 
 - interval: 1m


### PR DESCRIPTION
These changes accommodate the latest linting rules that are rolled up into mixtool.

Mostly, this is with regard to alerting rules which should follow the [mixin standards for alerts](https://monitoring.mixins.dev/#guidelines-for-alert-names-labels-and-annotations).