### PR TITLE
Logs dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,11 @@ Running `jsonnet -S lib/kubernetes_customised_alerts.jsonnet` will build the ale
 
 Same result can be achieved by modyfying the existing `config.libsonnet` with the content of `kubernetes_mixin_override.libsonnet`.
 
+### Loki logs dashboard
+
+Pod logs dashboard with loki datasource can be enabled/disabled with 
+`enableLokiLogs` option.
+
 ## Background
 
 ### Alert Severities

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -44,6 +44,7 @@
       'nodes.json': 'kcb9C2QDe4IYcjiTOmYyfhsImuzxRcvwWC3YLJPS',
       'persistentvolumesusage.json': 'AhCeikee0xoa6faec0Weep2nee6shaiquigahw8b',
       'pods.json': 'AMK9hS0rSbSz7cKjPHcOtk6CGHFjhSHwhbQ3sedK',
+      'pods-logs.json': 'add79da23c2c11eebe560242ac120002',
       'statefulset.json': 'dPiBt0FRG5BNYo0XJ4L0Meoc7DWs9eL40c1CRc1g',
       'k8s-resources-windows-cluster.json': '4d08557fd9391b100730f2494bccac68',
       'k8s-resources-windows-namespace.json': '490b402361724ab1d4c45666c1fa9b6f',
@@ -109,5 +110,13 @@
 
     // Default timeout value for k8s Jobs. The jobs which are active beyond this duration would trigger KubeJobNotCompleted alert.
     kubeJobTimeoutDuration: 12 * 60 * 60,
+
+    // Enable pod logs dashboard (loki datasource)
+    enableLokiLogs: false,
+
+    // Application label (used in logs selector)
+    applicationLabel: 'app',
+    logsVolumeGroupBy: self.applicationLabel,
+    showLogsVolume: true,
   },
 }

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -6,4 +6,5 @@
 (import 'scheduler.libsonnet') +
 (import 'proxy.libsonnet') +
 (import 'kubelet.libsonnet') +
-(import 'defaults.libsonnet')
+(import 'defaults.libsonnet') +
+(import 'pod-logs.libsonnet')

--- a/dashboards/pod-logs.libsonnet
+++ b/dashboards/pod-logs.libsonnet
@@ -1,0 +1,46 @@
+// add logs
+local g = import 'github.com/grafana/grafonnet/gen/grafonnet-v10.0.0/main.libsonnet';
+local logsDashboard = import 'github.com/grafana/jsonnet-libs/logs-lib/logs/main.libsonnet';
+
+{
+  local filterSelector = 'namespace!=""',
+  local labels = [$._config.clusterLabel, $._config.namespaceLabel, $._config.applicationLabel, $._config.podLabel, 'container'],
+
+  local formatParser = null,
+  local logsDash =
+    logsDashboard.new(
+      '%s Pod Logs' % $._config.grafanaK8s.dashboardNamePrefix,
+      datasourceRegex='',
+      filterSelector=filterSelector,
+      labels=labels,
+      formatParser=formatParser,
+      showLogsVolume=$._config.showLogsVolume,
+      logsVolumeGroupBy=$._config.logsVolumeGroupBy,
+      extraFilters=|||
+        | label_format timestamp="{{__timestamp__}}"
+        | line_format `{{ if eq "[[pod]]" ".*" }}{{.pod | trunc 20}}:{{else}}{{.container}}:{{end}} {{__line__}}`
+      |||
+    )
+
+    {
+      // overwrite dashboard 'log'
+      dashboards+:
+        {
+          logs+: g.dashboard.withLinksMixin($.grafanaDashboards['k8s-resources-cluster.json'].links)
+                 + g.dashboard.withUid($._config.grafanaDashboardIDs['pods-logs.json'])
+                 + g.dashboard.withTags($._config.grafanaK8s.dashboardTags)
+                 + g.dashboard.withRefresh($._config.grafanaK8s.refresh),
+        },
+      // overwrite panel 'log'
+      panels+:
+        {
+          logs+: g.panel.logs.options.withEnableLogDetails(true)
+                 + g.panel.logs.options.withShowTime(false),
+        },
+    },
+
+  grafanaDashboards+:: if $._config.enableLokiLogs then {
+    'pods-logs':
+      logsDash.dashboards.logs,
+  } else {},
+}

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -18,6 +18,15 @@
         }
       },
       "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "logs-lib"
+        }
+      },
+      "version": "vzhuravlev/logs-lib-update"
     }
   ],
   "legacyImports": false

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -29,5 +29,5 @@
       "version": "master"
     }
   ],
-  "legacyImports": false
+  "legacyImports": true
 }

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -26,7 +26,7 @@
           "subdir": "logs-lib"
         }
       },
-      "version": "vzhuravlev/logs-lib-update"
+      "version": "master"
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
This adds conditional pods logs dashboard by using [log library](https://github.com/grafana/jsonnet-libs/tree/master/logs-lib), that can be used to generate dashboard in any mixin (Linux, Windows, Clickhouse, MySQL, PostgreSQL etc) with custom chained label selectors.
 
![image](https://github.com/grafana/kubernetes-mixin/assets/14870891/abf3817e-001f-4de2-ad62-c6b2b5b072fb)

Features:
- Enable or disable dash with `enableLokiLogs`
- Use common kube labels as selectors: `['cluster', 'namespace', 'app', 'pod', 'container']` 
- Use free type `regex_search` variable to 'grep' lines as last resort
- Enable or disable graph that shows log volume grouped by applications (configurable)
- Smart line output:
  - Append with `pod` name by default. If pod variable is selected - append with `container`  name instead.
  - Don't show timestamps to preserve space, but store `timestamp` in additional field to have an option to view it.
