### PR TITLE
Split k8s.rules group into seven groups

### DIFF
--- a/rules/apps.libsonnet
+++ b/rules/apps.libsonnet
@@ -7,7 +7,7 @@
   prometheusRules+:: {
     groups+: [
       {
-        name: 'k8s.rules',
+        name: 'k8s.rules.container_cpu_usage_seconds_total',
         rules: [
           {
             // Reduces cardinality of this timeseries by #cores, which makes it
@@ -22,6 +22,11 @@
               )
             ||| % $._config,
           },
+        ],
+      },
+      {
+        name: 'k8s.rules.container_memory_working_set_bytes',
+        rules: [
           {
             record: 'node_namespace_pod_container:container_memory_working_set_bytes',
             expr: |||
@@ -31,6 +36,11 @@
               )
             ||| % $._config,
           },
+        ],
+      },
+      {
+        name: 'k8s.rules.container_memory_rss',
+        rules: [
           {
             record: 'node_namespace_pod_container:container_memory_rss',
             expr: |||
@@ -40,6 +50,11 @@
               )
             ||| % $._config,
           },
+        ],
+      },
+      {
+        name: 'k8s.rules.container_memory_cache',
+        rules: [
           {
             record: 'node_namespace_pod_container:container_memory_cache',
             expr: |||
@@ -49,6 +64,11 @@
               )
             ||| % $._config,
           },
+        ],
+      },
+      {
+        name: 'k8s.rules.container_memory_swap',
+        rules: [
           {
             record: 'node_namespace_pod_container:container_memory_swap',
             expr: |||


### PR DESCRIPTION
See https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/882

I had to update upstream first as Ops uses that repo, not this one.